### PR TITLE
Fixed link to reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ persistent/object storages such as S3 and also provides tools for restoring said
 
 ## Documentation
 
-* [Guardian reference](https://aiven.github.io/guardian-for-apache-kafka/) documentation.
+* [Guardian reference](https://aiven-open.github.io/guardian-for-apache-kafka/) documentation.
 
 ## Trademarks
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Fixed a broken link from README to reference documentation following repo move. 

# Why this way

Using the correct link instead of the broken one seemed like the right way to go :)
