### PR TITLE
Automatically include test name when logging

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -2,7 +2,6 @@ package io.aiven.guardian.kafka.backup.s3
 
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
-import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.Generators._
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
 import io.aiven.guardian.kafka.codecs.Circe._
@@ -13,6 +12,7 @@ import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import org.apache.pekko
 import org.mdedetrich.pekko.stream.support.CirceStreamSupport
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.TestData
 import org.scalatest.matchers.must.Matchers
 
 import scala.concurrent.ExecutionContext
@@ -27,12 +27,12 @@ import pekko.stream.scaladsl.Keep
 import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 
-trait BackupClientSpec extends S3Spec with Matchers with BeforeAndAfterAll with LazyLogging {
+trait BackupClientSpec extends S3Spec with Matchers with BeforeAndAfterAll {
 
   val ThrottleElements: Int          = 100
   val ThrottleAmount: FiniteDuration = 1 millis
 
-  property("backup method completes flow correctly for all valid Kafka events") {
+  property("backup method completes flow correctly for all valid Kafka events") { implicit td: TestData =>
     forAll(kafkaDataWithTimePeriodsGen(), s3ConfigGen(useVirtualDotHost, bucketPrefix)) {
       (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
         logger.info(s"Data bucket is ${s3Config.dataBucket}")

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupConsumerSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupConsumerSpec.scala
@@ -15,6 +15,7 @@ import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import io.aiven.guardian.pekko.AnyPropTestKit
 import org.apache.pekko
 import org.mdedetrich.pekko.stream.support.CirceStreamSupport
+import org.scalatest.TestData
 import org.scalatest.matchers.must.Matchers
 
 import scala.concurrent.ExecutionContext
@@ -44,7 +45,7 @@ class MockedKafkaClientBackupConsumerSpec
 
   property(
     "Creating many objects in a small period of time works despite S3's in progress multipart upload eventual consistency issues"
-  ) {
+  ) { implicit td: TestData =>
     forAll(
       kafkaDataWithTimePeriodsGen(20,
                                   20,

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
@@ -19,7 +19,8 @@ import io.aiven.guardian.kafka.s3.Generators.s3ConfigGen
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import org.apache.pekko
 import org.mdedetrich.pekko.stream.support.CirceStreamSupport
-import org.scalatest.propspec.AnyPropSpecLike
+import org.scalatest.TestData
+import org.scalatest.propspec.FixtureAnyPropSpecLike
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -35,7 +36,7 @@ import pekko.stream.connectors.s3.scaladsl.S3
 import pekko.stream.scaladsl.Compression
 import pekko.stream.scaladsl.Sink
 
-trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with BackupClientSpec {
+trait RealS3BackupClientTest extends FixtureAnyPropSpecLike with KafkaClusterTest with BackupClientSpec {
   def compression: Option[CompressionConfig]
 
   override lazy val s3Settings: S3Settings = S3Settings()
@@ -96,7 +97,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }).runWith(Sink.seq)
   }
 
-  property("basic flow without interruptions using PeriodFromFirst works correctly") {
+  property("basic flow without interruptions using PeriodFromFirst works correctly") { implicit td: TestData =>
     forAll(kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -173,7 +174,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("suspend/resume using PeriodFromFirst creates separate object after resume point") {
+  property("suspend/resume using PeriodFromFirst creates separate object after resume point") { implicit td: TestData =>
     forAll(kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -292,7 +293,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("suspend/resume for same object using ChronoUnitSlice works correctly") {
+  property("suspend/resume for same object using ChronoUnitSlice works correctly") { implicit td: TestData =>
     forAll(kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -387,7 +388,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("Backup works with multiple keys") {
+  property("Backup works with multiple keys") { implicit td: TestData =>
     forAll(kafkaDataWithTimePeriodsGen(min = 30000, max = 30000),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -467,7 +468,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("Concurrent backups using real Kafka cluster with a single key") {
+  property("Concurrent backups using real Kafka cluster with a single key") { implicit td: TestData =>
     forAll(
       kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
       s3ConfigGen(useVirtualDotHost, bucketPrefix),
@@ -589,7 +590,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("Concurrent backups using real Kafka cluster with a multiple keys") {
+  property("Concurrent backups using real Kafka cluster with a multiple keys") { implicit td: TestData =>
     forAll(
       kafkaDataWithTimePeriodsGen(min = 30000, max = 30000),
       s3ConfigGen(useVirtualDotHost, bucketPrefix),

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/CompressionSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/CompressionSpec.scala
@@ -32,7 +32,7 @@ class CompressionSpec
   // increase in the timeout
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 15 millis)
 
-  property("GZip compression works with a SourceWithContext/FlowWithContext") {
+  property("GZip compression works with a SourceWithContext/FlowWithContext") { _ =>
     forAll { data: List[String] =>
       val asByteString    = data.map(ByteString.fromString)
       val zippedWithIndex = asByteString.zipWithIndex

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/ConfigurationChangeRestartSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/ConfigurationChangeRestartSpec.scala
@@ -2,7 +2,6 @@ package io.aiven.guardian.kafka.backup
 
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
-import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.kafka.Generators.KafkaDataWithTimePeriod
 import io.aiven.guardian.kafka.Generators.kafkaDataWithTimePeriodsGen
 import io.aiven.guardian.kafka.TestUtils.waitForStartOfTimeUnit
@@ -43,8 +42,7 @@ class ConfigurationChangeRestartSpec
     with PekkoStreamTestKit
     with Matchers
     with ScalaFutures
-    with ScalaCheckPropertyChecks
-    with StrictLogging {
+    with ScalaCheckPropertyChecks {
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(90 seconds, 100 millis)
@@ -52,7 +50,7 @@ class ConfigurationChangeRestartSpec
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 1)
 
-  property("GZip compression enabled initially and then BackupClient restarted with compression disabled") {
+  property("GZip compression enabled initially and then BackupClient restarted with compression disabled") { _ =>
     implicit val generatorDrivenConfig: PropertyCheckConfiguration =
       PropertyCheckConfiguration(minSuccessful = 1)
 
@@ -118,7 +116,7 @@ class ConfigurationChangeRestartSpec
     }
   }
 
-  property("no compression enabled initially and then BackupClient restarted with GZip compression enabled") {
+  property("no compression enabled initially and then BackupClient restarted with GZip compression enabled") { _ =>
     forAll(kafkaDataWithTimePeriodsGen()) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
       val commitStorage = new ConcurrentLinkedDeque[Long]()
       val backupStorage = new ConcurrentLinkedQueue[(String, ByteString)]()

--- a/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/RestoreClientInterfaceTest.scala
+++ b/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/RestoreClientInterfaceTest.scala
@@ -2,7 +2,6 @@ package io.aiven.guardian.kafka.restore
 
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
-import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.kafka.ExtensionsMethods._
 import io.aiven.guardian.kafka.Generators._
 import io.aiven.guardian.kafka.Utils
@@ -16,7 +15,7 @@ import org.apache.pekko
 import org.scalatest.Inspectors
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.propspec.AnyPropSpecLike
+import org.scalatest.propspec.FixtureAnyPropSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.ExecutionContext
@@ -31,19 +30,18 @@ import java.time.temporal.ChronoUnit
 import pekko.stream.scaladsl.Source
 
 trait RestoreClientInterfaceTest
-    extends AnyPropSpecLike
+    extends FixtureAnyPropSpecLike
     with PekkoStreamTestKit
     with Matchers
     with ScalaFutures
-    with ScalaCheckPropertyChecks
-    with StrictLogging {
+    with ScalaCheckPropertyChecks {
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(90 seconds, 100 millis)
 
   def compression: Option[Compression]
 
-  property("Calculating finalKeys contains correct keys with fromWhen filter") {
+  property("Calculating finalKeys contains correct keys with fromWhen filter") { _ =>
     forAll(
       kafkaDataWithTimePeriodsAndPickedRecordGen(padTimestampsMillis =
                                                    Range.inclusive(1, ChronoUnit.HOURS.getDuration.toMillis.toInt),
@@ -84,7 +82,7 @@ trait RestoreClientInterfaceTest
     }
   }
 
-  property("Round-trip with backup and restore") {
+  property("Round-trip with backup and restore") { _ =>
     forAll(kafkaDataWithTimePeriodsGen()) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
       implicit val restoreConfig: RestoreConfig                               = RestoreConfig.empty
       implicit val mockedKafkaProducerInterface: MockedKafkaProducerInterface = new MockedKafkaProducerInterface
@@ -111,7 +109,7 @@ trait RestoreClientInterfaceTest
     }
   }
 
-  property("Round-trip with backup and restore works using fromWhen filter") {
+  property("Round-trip with backup and restore works using fromWhen filter") { _ =>
     forAll(
       kafkaDataWithTimePeriodsAndPickedRecordGen(padTimestampsMillis =
                                                    Range.inclusive(1, ChronoUnit.HOURS.getDuration.toMillis.toInt),

--- a/core/src/test/scala/io/aiven/guardian/pekko/AnyPropTestKit.scala
+++ b/core/src/test/scala/io/aiven/guardian/pekko/AnyPropTestKit.scala
@@ -1,11 +1,15 @@
 package io.aiven.guardian.pekko
 
 import org.apache.pekko
-import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.fixture
+import org.scalatest.propspec.FixtureAnyPropSpecLike
 
 import pekko.actor.ActorSystem
 import pekko.testkit.TestKitBase
 
-class AnyPropTestKit(_system: ActorSystem) extends AnyPropSpec with TestKitBase {
+class AnyPropTestKit(_system: ActorSystem)
+    extends FixtureAnyPropSpecLike
+    with TestKitBase
+    with fixture.TestDataFixture {
   implicit val system: ActorSystem = _system
 }

--- a/core/src/test/scala/io/aiven/guardian/pekko/PekkoStreamTestKit.scala
+++ b/core/src/test/scala/io/aiven/guardian/pekko/PekkoStreamTestKit.scala
@@ -1,8 +1,12 @@
 package io.aiven.guardian.pekko
 
+import com.typesafe.scalalogging.CanLog
+import com.typesafe.scalalogging.Logger
+import com.typesafe.scalalogging.LoggerTakingImplicit
 import org.apache.pekko
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Suite
+import org.scalatest.TestData
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -21,4 +25,11 @@ trait PekkoStreamTestKit extends TestKitBase with BeforeAndAfterAll { this: Suit
     * wait, make sure you wait at least this period of time for akka-streams to initialize properly.
     */
   val PekkoStreamInitializationConstant: FiniteDuration = 1 second
+
+  private implicit case object CanLogTestData extends CanLog[TestData] {
+    override def logMessage(originalMsg: String, context: TestData): String =
+      s"${context.name}: $originalMsg"
+  }
+
+  lazy val logger: LoggerTakingImplicit[TestData] = Logger.takingImplicit[TestData](getClass.getName)
 }

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
@@ -18,8 +18,9 @@ import io.aiven.guardian.kafka.s3.S3Spec
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.pekko
+import org.scalatest.TestData
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.propspec.AnyPropSpecLike
+import org.scalatest.propspec.FixtureAnyPropSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.Future
@@ -37,7 +38,7 @@ import pekko.stream.connectors.s3.scaladsl.S3
 import pekko.stream.scaladsl.Sink
 
 trait RealS3RestoreClientTest
-    extends AnyPropSpecLike
+    extends FixtureAnyPropSpecLike
     with S3Spec
     with Matchers
     with KafkaClusterTest
@@ -63,7 +64,7 @@ trait RealS3RestoreClientTest
   override lazy val bucketPrefix: Option[String]          = Some("guardian-")
   override lazy val enableCleanup: Option[FiniteDuration] = Some(5 seconds)
 
-  property("Round-trip with backup and restore") {
+  property("Round-trip with backup and restore") { implicit td: TestData =>
     forAll(
       kafkaDataWithMinSizeRenamedTopicsGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
       s3ConfigGen(useVirtualDotHost, bucketPrefix),


### PR DESCRIPTION
# About this change - What it does

The PR adds in the test name when doing `logger.info`

# Why this way

The are 2 primary changes that allow for us to automatically add the test name to logging

* Configure the code so that we use a TestFixture. You can see https://stackoverflow.com/a/14836709/1519631 but a Fixture is ScalaTest terminology for passing in context via a parameter into an anonymous function (in ScalaTest your tests are written as anonymous functions). In this case use `TestData` (which contains data about the test being run) for our test fixture
* ScalaLogging's [LoggingTakingImplicit](https://github.com/lightbend-labs/scala-logging#using-scala-logging) which allows you to create a logger that takes in this `TestData`. Since its an implicit its verified at compile time, but this is what allows us to do `logger.info` which automatically includes data about the test (such as the test name).


```
io.aiven.guardian.kafka.backup.s3.RealS3GzipCompressionBackupClientSpec - backup method completes flow correctly for all valid Kafka events: Data bucket is guardian-4wdsljhfec--vbbsynasrppg99okcno4k-pn
```

Is an example of an output log, note how it has `backup method completes flow correctly for all valid Kafka events` which is the test name