### PR TITLE
Fix documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ persistent/object storages such as S3 and also provides tools for restoring said
 
 ## Documentation
 
-* [Guardian reference](https://aiven.github.io/guardian-for-apache-kafka/) documentation.
+* [Guardian reference](https://aiven-open.github.io/guardian-for-apache-kafka/) documentation.
 
 ## Trademarks
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Fix documentation link in README.md

# Why this way

The repository migrated to new organization, so the documentation migrated to new URL as well.
