### PR TITLE
Fix permissions for dependency graph submission

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main # default branch of the project
+permissions:
+  contents: write
 jobs:
   dependency-graph:
     name: Update Dependency Graph


### PR DESCRIPTION
# About this change - What it does

Add write permission to github job

# Why this way

Default github permissions have changed so this needs to be explicit, otherwise you get this issue https://github.com/Aiven-Open/guardian-for-apache-kafka/actions/runs/6016582389/job/16320935902
