### PR TITLE
Wait for materialized value before completing in chunk upload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,14 @@ ThisBuild / organization         := "aiven.io"
 ThisBuild / organizationName     := "Aiven"
 ThisBuild / organizationHomepage := Some(url("https://aiven.io/"))
 
+// Remove when Pekko Connectors 1.0.2 is out
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+
 val pekkoVersion                = "1.0.1"
 val pekkoHttpVersion            = "1.0.0"
 val pekkoConnectorsKafkaVersion = "1.0.0"
 val kafkaClientsVersion         = "3.6.0"
-val pekkoConnectorsVersion      = "1.0.0"
+val pekkoConnectorsVersion      = "1.0.1+9-32facdd8-SNAPSHOT"
 val futilesVersion              = "2.0.2"
 val quillJdbcMonixVersion       = "3.7.2"
 val postgresqlJdbcVersion       = "42.6.0"


### PR DESCRIPTION
# About this change - What it does

Currently in Pekko we ignore the result when a chunk upload sink is uploaded, this PR fixes that.

# Why this way

Originally when I wrote the `kafkaBatchSink` I wasn't that familiar with the graphDSL and in its original implementation I didn't pass in the `successSink`/`failureGraph` into the graph. What this meant is that while the core business logic would run, it wouldn't wait on completion of either the `successSink` or `failureSink`.

This PR requires a snapshot version of Pekko connectors due to needing this change https://github.com/apache/incubator-pekko-connectors/pull/280