### PR TITLE
Remove deprecated splitAfter functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / organizationHomepage := Some(url("https://aiven.io/"))
 // Remove when Pekko Connectors 1.0.2 is out
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
-val pekkoVersion                = "1.0.2"
+val pekkoVersion                = "1.1.0-M0+204-d829637e-SNAPSHOT" // Change to 1.1.0 when its released
 val pekkoHttpVersion            = "1.0.0"
 val pekkoConnectorsKafkaVersion = "1.0.0"
 val kafkaClientsVersion         = "3.6.1"


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Updates to latest snapshot of Pekko which fixes currently existing issues with `splitAfter`/`SubstreamCancelStrategy`.

# Why this way

Since https://github.com/apache/incubator-pekko/pull/252 was merged and released as a snapshot, this PR applies the changes necessary as documented in the [migration steps](https://pekko.apache.org/docs/pekko/snapshot/project/migration-guide-1.0.x-1.1.x.html#source-splitwhen-flow-splitwhen-source-splitafter-flow-splitafter-behavioural-change).

In summary, the relevant behavioural changes is that rather than `splitAfter` using a `SubstreamCancelStrategy` it instead resuses the already existing [`SupervisionDecider`](https://github.com/Aiven-Open/guardian-for-apache-kafka/blob/db4f3feae5948248a218179e830bb71ad20f23ba/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala#L24-L31) which logs an exception (if it occurs) and cancels the stream due to that exception.