### PR TITLE
Update scalafmt native github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,6 @@ jobs:
           persist-credentials: false
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v2
+        uses: jrouly/scalafmt-native-action@v3
         with:
-          version: '3.7.17'
           arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
# About this change - What it does

Updates the scalafmt github action to version 3

# Why this way

The notable change in this updated version is that it no longer needs a hardcoded version, instead it can read the version from https://github.com/Aiven-Open/guardian-for-apache-kafka/blob/f294e464e9c4adc0bbf8bbe416414af4700312d8/.scalafmt.conf#L1 which means that scala-steward can now make proper scalafmt update PR's
