### PR TITLE
Add workflow dispatch

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
This change allows a manual trigger of Scala Steward instead of having to wait for the cron job